### PR TITLE
Update restforce dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       delayed_job_active_record (>= 4.1.1)
       event_bus (>= 1.1.1)
       rails (>= 3.0)
-      restforce (>= 2.2.0)
+      restforce (>= 3.0.0)
       salesforce_bulk_api (>= 0.0.12)
 
 GEM
@@ -58,13 +58,13 @@ GEM
     diff-lcs (1.3)
     erubis (2.7.0)
     event_bus (1.1.1)
-    faraday (0.12.2)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
-    hashie (3.5.6)
+    hashie (3.6.0)
     hike (1.2.3)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
@@ -114,7 +114,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
-    restforce (2.5.3)
+    restforce (3.1.0)
       faraday (>= 0.9.0, <= 1.0)
       faraday_middleware (>= 0.8.8, <= 1.0)
       hashie (>= 1.2.0, < 4.0)
@@ -163,4 +163,4 @@ DEPENDENCIES
   timecop (>= 0.6.3)
 
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/salesforce_sync.gemspec
+++ b/salesforce_sync.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "rails", [">= 3.0"]
   s.add_runtime_dependency "delayed_job_active_record", [">= 4.1.1"]
   s.add_runtime_dependency "event_bus", [">= 1.1.1"]
-  s.add_runtime_dependency "restforce", [">= 2.2.0"]
+  s.add_runtime_dependency "restforce", [">= 3.0.0"]
   s.add_runtime_dependency "salesforce_bulk_api", [">= 0.0.12"]
 
   s.add_development_dependency "rspec", [">= 3.5"]


### PR DESCRIPTION
Update restforce dependency from 2.5.3 to 3.1.0.
The only breaking change is the deprecated support for ruby 2.2 (we are using ruby 2.3)
https://github.com/restforce/restforce/blob/master/CHANGELOG.md

This fixes a vulnerability with restforce: https://nvd.nist.gov/vuln/detail/CVE-2018-3777